### PR TITLE
Fix automaton for second top string

### DIFF
--- a/a.cpp
+++ b/a.cpp
@@ -6,7 +6,7 @@ using namespace std;
 // `other_first` is the first state index of the other string.
 static void build(const string& s, int start, int other_first,
                   vector<char>& C, vector<vector<int>>& A) {
-    const int M = 12;
+    const int M = C.size();
 
     // Collect unique letters used in the string.
     vector<char> letters;
@@ -53,9 +53,12 @@ static void build(const string& s, int start, int other_first,
 
         char c = states[i];
         vector<char> options(nxt[c - 'a'].begin(), nxt[c - 'a'].end());
-        if (options.size() > 3) options.resize(3);
         int k = options.size();
-        int prob = (k == 3 ? 33 : 41);
+        int prob = 0;
+        if (k == 1) prob = 41;
+        else if (k == 2) prob = 41;
+        else if (k == 3) prob = 33;
+        else if (k > 0) prob = 99 / k; // fallback for rare cases
         for (int t = 0; t < k; t++) {
             int dest = char_to_state[options[t] - 'a'];
             if (dest == -1) dest = start; // fallback

--- a/next_action.txt
+++ b/next_action.txt
@@ -8,3 +8,4 @@
 - Merged transitions from top four strings into a single 12-state automaton with at most three next letters per state.
 - run_all_par.sh failed because tester.exe is missing.
 - Fixed probability distribution bug: leftover transitions no longer add to next-letter states.
+- Found probability 0 bug for second-best string because transitions with more than 3 options were truncated. Updated build() to keep all options and distribute 99/k when k>3.


### PR DESCRIPTION
## Summary
- handle any number of next letters when building automaton
- derive state count from `C` size
- document fix in `next_action.txt`

## Testing
- `bash run_all_par_sh.sh`
- `python3 compute_score.py in/0002.txt <(./a.out < in/0002.txt)`