### PR TITLE
Implement progress output in annealing loop

### DIFF
--- a/a.cpp
+++ b/a.cpp
@@ -772,9 +772,23 @@ static void anneal_matrix(const vector<string>& S, const vector<int>& P,
     long long cur = fast_score(S, P, L, C, curA);
     long long best = cur;
 
+    auto print_solution = [&](const vector<char>& C, const vector<vector<int>>& A) {
+        for (int i = 0; i < M; i++) {
+            cout << C[i];
+            for (int j = 0; j < M; j++) {
+                cout << ' ' << A[i][j];
+            }
+            cout << '\n';
+        }
+        cout.flush();
+    };
+
     auto start = chrono::steady_clock::now();
     const double TL = 1.5;
+    int loop = 0;
     while (chrono::duration<double>(chrono::steady_clock::now() - start).count() < TL) {
+        ++loop;
+        cerr << loop << "\n";
         int i = rand_int(0, M - 1);
         int j1 = rand_int(0, M - 1);
         int j2 = rand_int(0, M - 1);
@@ -791,6 +805,9 @@ static void anneal_matrix(const vector<string>& S, const vector<int>& P,
             if (sc > best) {
                 best = sc;
                 bestA = curA;
+                if (loop >= 1000) {
+                    print_solution(C, bestA);
+                }
             }
         } else {
             curA[i][j1] += delta;


### PR DESCRIPTION
## Summary
- add a lambda to print current solution
- output loop count to stderr in the annealing loop
- after 1000 iterations, print the solution each time the best score improves

## Testing
- `g++ a.cpp -O2 -std=c++17 -Wall -o a.out`
- `for i in $(seq -f "%04g" 0 14); do ./a.out < in/$i.txt > out/out_$i.txt 2> err/err_$i.txt; score=$(python3 compute_score.py in/$i.txt out/out_$i.txt); echo "score $i: $score"; done`