### PR TITLE
Improve annealing settings and scoring output

### DIFF
--- a/a.cpp
+++ b/a.cpp
@@ -784,7 +784,7 @@ static void anneal_matrix(const vector<string>& S, const vector<int>& P,
     };
 
     auto start = chrono::steady_clock::now();
-    const double TL = 1.5;
+    const double TL = 3.0;
     int loop = 0;
     while (chrono::duration<double>(chrono::steady_clock::now() - start).count() < TL) {
         ++loop;
@@ -815,6 +815,8 @@ static void anneal_matrix(const vector<string>& S, const vector<int>& P,
     }
     A = bestA;
     cerr << "loop = " << loop << "\n";
+    long long best_score = compute_score(S, P, L, C, A);
+    cerr << "Best Score = " << best_score << "\n";
 }
 
 // Simulated annealing focusing on the top four strings.

--- a/run_all_par_sh.sh
+++ b/run_all_par_sh.sh
@@ -17,6 +17,7 @@ if [ ! -f "$CPP_EXECUTABLE" ]; then
     exit 1
 fi
 mkdir -p "$OUTPUT_DIR"
+mkdir -p "$ERR_DIR"
 > "$SCORE_FILE" # スコアファイルを初期化
 
 # --- 並列実行数を設定 ---
@@ -27,7 +28,7 @@ MAX_JOBS=1
 echo "Starting tests with up to $MAX_JOBS parallel jobs..."
 
 # --- テストケース番号のリストを生成 ---
-find "$INPUT_DIR" -maxdepth 1 -name '????.txt' -printf '%f\n' | sed 's/\.txt$//' | sort | \
+find "$INPUT_DIR" -maxdepth 1 -name '????.txt' -printf '%f\n' | sed 's/\.txt$//' | sort | head -n 15 | \
 xargs -I {} -P "$MAX_JOBS" \
 bash -c '
     filenum="{}"  # xargsから渡されたファイル番号


### PR DESCRIPTION
## Summary
- report best score to stderr so `run_all_par_sh.sh` can gather results
- ensure `run_all_par_sh.sh` creates `err` directory and only runs the first 15 cases
- extend annealing runtime to 3s and keep delta small for better scores

## Testing
- `bash run_all_par_sh.sh`