### PR TITLE
Add edge-limited solver

### DIFF
--- a/edge_30.cpp
+++ b/edge_30.cpp
@@ -1,0 +1,72 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int main(){
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+
+    int N,M; long long L;
+    if(!(cin>>N>>M>>L)) return 0;
+    vector<string> S(N); vector<int> P(N);
+    for(int i=0;i<N;i++) cin>>S[i]>>P[i];
+
+    // count weighted bigram frequencies
+    const int K=6; // letters a..f
+    vector<vector<long long>> cnt(K, vector<long long>(K,0));
+    for(int idx=0; idx<N; idx++){
+        const string& w=S[idx];
+        long long weight=P[idx];
+        for(size_t i=0; i<w.size(); i++){
+            char a=w[i];
+            char b=w[(i+1)%w.size()];
+            cnt[a-'a'][b-'a'] += weight;
+        }
+    }
+
+    // pick top 30 edges
+    struct Edge{int u,v; long long w;};
+    vector<Edge> edges;
+    for(int u=0; u<K; u++) for(int v=0; v<K; v++){
+        edges.push_back({u,v,cnt[u][v]});
+    }
+    sort(edges.begin(), edges.end(), [](const Edge& a, const Edge& b){return a.w>b.w;});
+    const int LIMIT=30;
+    vector<vector<int>> allowed(K, vector<int>(K,0));
+    for(int i=0; i<min((int)edges.size(), LIMIT); i++){
+        allowed[edges[i].u][edges[i].v]=1;
+    }
+
+    // build state letters (12 states: abcdefabcdef)
+    vector<char> C(M);
+    string letters="abcdef";
+    for(int i=0;i<M;i++) C[i]=letters[i%letters.size()];
+
+    // gather state indices for each letter
+    vector<vector<int>> by(K);
+    for(int i=0;i<M;i++) by[C[i]-'a'].push_back(i);
+
+    vector<vector<int>> A(M, vector<int>(M,0));
+    for(int i=0;i<M;i++){
+        int from=C[i]-'a';
+        vector<int> dests;
+        for(int v=0; v<K; v++) if(allowed[from][v]){
+            for(int idx: by[v]) dests.push_back(idx);
+        }
+        if(dests.empty()){
+            A[i][i]=100;
+            continue;
+        }
+        int k=dests.size();
+        for(int idx=0; idx<k; idx++) A[i][dests[idx]] = 100/k;
+        for(int idx=0; idx<100%k; idx++) A[i][dests[idx]]++;
+    }
+
+    cerr << "Generated with " << LIMIT << " edges" << "\n";
+    for(int i=0;i<M;i++){
+        cout<<C[i];
+        for(int j=0;j<M;j++) cout<<' '<<A[i][j];
+        cout<<"\n";
+    }
+    return 0;
+}
+

--- a/next_action.txt
+++ b/next_action.txt
@@ -12,3 +12,4 @@
 - Added anneal_matrix move that boosts probabilities along a random path for one of top 7 strings.
 - Implemented weighted bigram initialization and updated solver (score 716385).
 - Added simple enumeration solver b.cpp choosing between two top strings for each state. Score ~725k on sample.
+- Implemented simple edge-limited solver edge_30.cpp selecting top 30 letter transitions by weighted frequency. Total score ~32k.

--- a/run_all_par_sh.sh
+++ b/run_all_par_sh.sh
@@ -4,7 +4,7 @@
 cd "$(dirname "$0")"
 
 # Build the solver
-g++ a.cpp -o a.out -std=c++20 -O2 -Wall
+g++ edge_30.cpp -o a.out -std=c++20 -O2 -Wall
 
 # --- 設定 (以前のスクリプトと同様) ---
 CPP_EXECUTABLE="./a.out"
@@ -50,16 +50,19 @@ bash -c '
 
     status=$?  # wsl コマンドの終了ステータス
 
-    # スコアファイルに結果を追記
+    # Compute score using Python scorer
     if [ $status -ne 0 ]; then
-        echo "Case $filenum: Tester Failed (status: $status)" >> "$score_file"
-        echo "Test case $filenum Failed (tester exited with status: $status)"
-    elif grep -q "^Best" "$err_file"; then
-        grep "^Best" "$err_file" | sed "s/^/Case $filenum: /" >> "$score_file"
-        echo "Test case $filenum Done."
+        echo "Case $filenum: Solver Failed (status: $status)" >> "$score_file"
+        echo "Test case $filenum Failed (solver exited with status: $status)"
     else
-        echo "Case $filenum: Failed (No Score line found)" >> "$score_file"
-        echo "Test case $filenum Failed (No Score line found)"
+        score=$(python3 compute_score.py "$input_file" "$output_file" 2>> "$err_file")
+        if [ $? -ne 0 ]; then
+            echo "Case $filenum: Scoring Failed" >> "$score_file"
+            echo "Test case $filenum Scoring Failed"
+        else
+            echo "Case $filenum: Score = $score" >> "$score_file"
+            echo "Test case $filenum Done."
+        fi
     fi
 
     # 出力ファイルが空でないか確認


### PR DESCRIPTION
## Summary
- add `edge_30.cpp` implementing a simple solver that limits to 30 transitions
- modify `run_all_par_sh.sh` to compile and score the new solver
- document the attempt in `next_action.txt`

## Testing
- `bash run_all_par_sh.sh > test_before.log` (score before: 715943)
- `bash run_all_par_sh.sh > test_after.log` (score after: 32269)